### PR TITLE
rename ClusterClient to SentinelClient

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@ use redis::{ErrorKind, IntoConnectionInfo};
 ///
 /// see: https://redis.io/topics/sentinel
 #[derive(Debug, Clone)]
-pub struct ClusterClient {
+pub struct SentinelClient {
     /// connects to any available sentinel and fetches the IP of the master node
     sentinel_client: redis::Client,
     client: redis::Client,
@@ -14,7 +14,7 @@ pub struct ClusterClient {
     namespace: String,
 }
 
-impl ClusterClient {
+impl SentinelClient {
     /// Connects to a redis-server in sentinel mode (used in redis clusters) and
     /// return a client pointing to the current master.
     /// This opens a short-lived connection to the sentinal server, then uses the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,4 @@
 
 mod client;
 
-pub use client::ClusterClient;
+pub use client::SentinelClient;


### PR DESCRIPTION
As far as I understand, Redis Cluster provides sharding and Redis Sentinel provides replication and high availability.

Even though the client in this crate connects to cluster (lowercase c) it seems confusing in comparison with client of Cluster (capital C).

So I renamed `ClusterClient` to `SentinelClient` and my code now looks like:

```rust
pub enum RedisService {
    Simple { client: Client },
    Cluster { client: ClusterClient },
    Sentinel { client: SentinelClient },
}
```