### PR TITLE
Support for multinode sentinel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # redis-sentinel-rs
 
-Plugin for the [Redis rust client library](https://github.com/mitsuhiko/redis-rs) which adds a
+Plugin for the Rust Redis client library [redis-rs](https://github.com/mitsuhiko/redis-rs) which adds a
 wrapper around `redis::Client` which first queries a sentinel server.
 
 **This is mostly incomplete and work-in-progress, but should work for the most basic use-case.**
+
+Provides only async API and does not handle connection pooling.
 
 Feel free to open an issue or a pull-request!
 
 Links:
 - [Redis sentinel documentation](https://redis.io/topics/sentinel)
+- [Redis sentinel clients guidelines](https://redis.io/topics/sentinel-clients)
 - [redis-rs documentation](https://docs.rs/redis/0.19.0/redis/)
 
 TODO:


### PR DESCRIPTION
During my efforts to deploy this library to a cluster with HA multi-node sentinel deployment, I had to make more changes.

The main problem was that the library used to connect to only one sentinel instance. If that instance went offline, library would not be able to establish new connections.

During the process I have encountered [official Redis guidelines](https://redis.io/topics/sentinel-clients) for sentinel client libraries and rewritten a big chunk of the library. 

Unfortunately, the commit cannot be merged with your latest changes. If you decide to merge it anyways, consider that:
- I dropped support for sync connections
- I have added configuration properties for connections to master node (like password or database)